### PR TITLE
Fix for getApiLimit

### DIFF
--- a/lib/cloudstack_client/connection.rb
+++ b/lib/cloudstack_client/connection.rb
@@ -73,7 +73,7 @@ module CloudstackClient
           return body.reject { |key, _| key == 'count' }.values.first
         elsif body.size == 1 && body.values.first.respond_to?(:keys)
           item = body.values.first
-          return item.is_a?(Array) ? item : []
+          return (item.is_a?(Array) || item.is_a?(Hash)) ? item : []
         else
           body.reject! { |key, _| key == 'count' } if body.key?('count')
           body.size == 0 ? [] : body


### PR DESCRIPTION
I tried [getApiLimit](https://cloudstack.apache.org/api/apidocs-4.3/user/getApiLimit.html) via following command. However, it returned empty array.

```
bundle exec ./bin/cloudstack-cli command getApiLimit
```

I fixed to handle even Hash not only Array to response data.
Could you Check this commit.