### PR TITLE
Support for maps values of values

### DIFF
--- a/lib/cloudstack_client/connection.rb
+++ b/lib/cloudstack_client/connection.rb
@@ -40,6 +40,12 @@ module CloudstackClient
             items.each {|k, v| map << "#{key}[#{i}].#{k}=#{escape(v)}"}
           end
           map.sort.join("&")
+        # support for maps values of values (Hash values of Hashes)
+        elsif value.is_a?(Hash)
+          value.each_with_index.map do |(k, v), i|
+            "#{key}[#{i}].key=#{escape(k)}&" +
+            "#{key}[#{i}].value=#{escape(v)}"
+          end.join("&")
         else
           "#{key}=#{escape(value)}"
         end


### PR DESCRIPTION
I tried display of virtual_machines with tags argument over [listVirtualMachines API](https://cloudstack.apache.org/api/apidocs-4.2/user/listVirtualMachines.html) command that supported by cloudstack API . However, it failed with the following error message.

```
/usr/local/lib64/ruby/gems/2.2.0/gems/cloudstack_client-1.4.0/lib/cloudstack_client/connection.rb:92:in `send_request': Status 431: Unable to execute API command listvirtualmachines due to invalid value {"scalable"=>"false"} for parameter tags. (CloudstackClient::ApiError)
	from /usr/local/lib64/ruby/gems/2.2.0/gems/cloudstack_client-1.4.0/lib/cloudstack_client/client.rb:38:in `block (2 levels) in define_api_methods'
```

I fixed in this commit and It was successful and the results were as expected.
Could you Check this commit.