### PR TITLE
Allowed asterisk character in the request body

### DIFF
--- a/lib/cloudstack_client/connection.rb
+++ b/lib/cloudstack_client/connection.rb
@@ -155,7 +155,10 @@ module CloudstackClient
     end
 
     def escape(input)
-      CGI.escape(input.to_s).gsub('+', '%20').gsub(' ', '%20')
+      CGI.escape(input.to_s)
+        .gsub('+', '%20')
+        .gsub(' ', '%20')
+        .gsub('%2A', '*')
     end
 
     def symbolized_key(name)


### PR DESCRIPTION
There is a known issue with sending requests to CloudStack where the asterisk `*` character is not handled properly by the ACS:
https://github.com/apache/cloudstack-cloudmonkey/issues/154

> If you have API calls which contain * (asterisk) characters, you will need to add the option “safe = ‘*’” for the URL encoding. The reason is that Python’s urllib will encode * characters by default, while CloudStack’s internal encoder does not encode them; this results in an authentication failure for your API call. In the above you would replace “urllib.quote_plus(request[k])” with “urllib.quote_plus(request[k], safe=’*’)”.

Footprints: 
https://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started/en/latest/dev.html


The `CGI.escape` does not have a safe parameter, causing the `*` character to be correctly encoded (into `%2A`), but this value isn't parsed correctly on the ACS side. This results in the error "Status 401: unable to verify user credentials and/or request signature" when body contains `*` character