### PR TITLE
feat(connection): Add per-request async_timeout and async_poll_interval for async API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ options = {
 cs = CloudstackClient::Client.new(config[:url], config[:api_key], config[:secret_key], options)
 ```
 
+For a single call you can override defaults on the **second** hash (client options), without changing the client instance:
+
+```ruby
+cs.deploy_virtual_machine({ zoneid: "...", serviceofferingid: "...", templateid: "..." },
+                          async_timeout: 600, async_poll_interval: 5)
+```
+
 ### Interactive Console
 
 cloudstack_client comes with an interactive console.

--- a/lib/cloudstack_client/connection.rb
+++ b/lib/cloudstack_client/connection.rb
@@ -97,6 +97,10 @@ module CloudstackClient
     # The contents of the 'jobresult' element are returned upon completion of the command.
 
     def send_async_request(params, opts = {})
+      request_timeout = opts[:async_timeout] || @async_timeout
+      poll_interval = opts[:async_poll_interval] || @async_poll_interval
+      validate_async_timeouts!(request_timeout, poll_interval)
+
       data = send_request(params, opts)
 
       params = {
@@ -104,7 +108,7 @@ module CloudstackClient
         'jobid' => data[k('jobid')]
       }
 
-      max_tries.times do
+      max_tries(request_timeout, poll_interval).times do
         data = send_request(params)
         print "." if @verbose
 
@@ -116,7 +120,7 @@ module CloudstackClient
         end
 
         STDOUT.flush if @verbose
-        sleep @async_poll_interval
+        sleep poll_interval
       end
 
       raise TimeoutError, "Asynchronous request timed out."
@@ -128,9 +132,13 @@ module CloudstackClient
       raise InputError, "API URL not set." if @api_url == nil
       raise InputError, "API KEY not set." if @api_key == nil
       raise InputError, "API SECRET KEY not set." if @secret_key == nil
-      raise InputError, "ASYNC POLL INTERVAL must be at least 1." if @async_poll_interval < 1.0
-      raise InputError, "ASYNC TIMEOUT must be at least 60." if @async_timeout < 60
+      validate_async_timeouts!(@async_timeout, @async_poll_interval)
       raise InputError, "REQUEST RETRIES must be at least 1." if @request_retries < 1
+    end
+
+    def validate_async_timeouts!(timeout, interval)
+      raise InputError, "ASYNC POLL INTERVAL must be at least 1." if interval < 1.0
+      raise InputError, "ASYNC TIMEOUT must be at least 60." if timeout < 60
     end
 
     def params_to_data(params)
@@ -160,8 +168,8 @@ module CloudstackClient
       CGI.escape(signature)
     end
 
-    def max_tries
-      (@async_timeout / @async_poll_interval).round
+    def max_tries(timeout, interval)
+      (timeout / interval).round
     end
 
     def escape(input)


### PR DESCRIPTION
This change introduces an extended_async_client to increase async_timeout only for operations that require more time, instead of modifying the global timeout.

Improves reliability of long-running async operations without affecting default behavior.