### PR TITLE
Fix using the gem outside of cloudstack-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ options = {
   symbolize_keys: true, # pass symbolize_names: true in JSON#parse for Cloudstack responses, default: false
   host: 'localhost', # custom host header to be used in Net::Http. May be useful when Cloudstack is set up locally via docker (i.e. Cloudstack-simulator), default: parsed from config[:url] via Net::Http
   read_timeout: 10, # timeout in seconds of a connection to the Cloudstack, default: 60
-  request_retries: 3 # number of attempts for HTTP requests before raising a ConnectionError, default: 1 (no retries). Uses incremental back-off between attempts.
+  request_retries: 3, # number of attempts for HTTP requests before raising a ConnectionError, default: 1 (no retries). Uses incremental back-off between attempts.
+  ssl_verify: false # whether to verify the server certificate on https connections, default: true. Set to false for a CloudStack using a self-signed certificate.
 }
 cs = CloudstackClient::Client.new(config[:url], config[:api_key], config[:secret_key], options)
 ```

--- a/lib/cloudstack_client/connection.rb
+++ b/lib/cloudstack_client/connection.rb
@@ -1,4 +1,3 @@
-require "base64"
 require "openssl"
 require "uri"
 require "cgi"
@@ -10,6 +9,7 @@ module CloudstackClient
     include Utils
 
     attr_accessor :api_url, :api_key, :secret_key, :verbose, :debug, :symbolize_keys, :host, :read_timeout
+    attr_accessor :ssl_verify
     attr_accessor :async_poll_interval, :async_timeout, :request_retries
 
     DEF_POLL_INTERVAL = 2.0
@@ -29,6 +29,7 @@ module CloudstackClient
       @async_poll_interval = options[:async_poll_interval] || DEF_POLL_INTERVAL
       @async_timeout = options[:async_timeout] || DEF_ASYNC_TIMEOUT
       @request_retries = options[:request_retries] || DEF_REQUEST_RETRIES
+      @ssl_verify = options.fetch(:ssl_verify, true)
       @options = options
       validate_input!
     end
@@ -48,14 +49,14 @@ module CloudstackClient
       http = Net::HTTP.new(uri.host, uri.port)
       if uri.scheme == 'https'
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = @ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
       end
       http.read_timeout = @read_timeout
 
       retries = 0
       begin
         req = Net::HTTP::Get.new(uri.request_uri)
-        req['Host'] = host if host.present?
+        req['Host'] = host unless host.nil? || host.to_s.empty?
         response = http.request(req)
       rescue => e
         retries += 1
@@ -164,7 +165,7 @@ module CloudstackClient
 
     def create_signature(data)
       signature = OpenSSL::HMAC.digest('sha1', @secret_key, data.downcase)
-      signature = Base64.encode64(signature).chomp
+      signature = [signature].pack('m0')
       CGI.escape(signature)
     end
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+# A stand-in for Net::HTTP that records what it was configured with and
+# returns a canned response, so the connection can be exercised without a
+# network or an HTTP stubbing library.
+class FakeHttp
+  attr_reader :requests
+  attr_accessor :use_ssl, :verify_mode, :read_timeout
+
+  def initialize(body:, code: "200")
+    @body = body
+    @code = code
+    @requests = []
+  end
+
+  def request(req)
+    @requests << req
+    response_class = @code == "200" ? Net::HTTPOK : Net::HTTPBadRequest
+    response = response_class.new("1.1", @code, "")
+    response.instance_variable_set(:@body, @body)
+    response.instance_variable_set(:@read, true)
+    response
+  end
+end
+
+describe CloudstackClient::Connection do
+  API_URL = "https://cloudstack.api/client/api".freeze
+
+  ZONES_BODY = JSON.dump(
+    "listzonesresponse" => { "count" => 1, "zone" => [{ "id" => "z1" }] }
+  ).freeze
+
+  # Swaps Net::HTTP.new for one returning +fake+, for the block's duration.
+  def with_fake_http(fake)
+    original = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |*_args| fake }
+    yield fake
+  ensure
+    Net::HTTP.define_singleton_method(:new, original)
+  end
+
+  def connection(options = {})
+    CloudstackClient::Connection.new(
+      API_URL, "test-key", "test-secret", { quiet: true }.merge(options)
+    )
+  end
+
+  describe "when sending a request without ActiveSupport loaded" do
+    it "must not raise when no host option is given" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do
+        _(connection.send_request("command" => "listZones")).must_equal [{ "id" => "z1" }]
+      end
+    end
+
+    it "must not set a Host header when no host option is given" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do |fake|
+        connection.send_request("command" => "listZones")
+        _(fake.requests.first["Host"]).must_be_nil
+      end
+    end
+
+    it "must not set a Host header when the host option is empty" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do |fake|
+        connection(host: "").send_request("command" => "listZones")
+        _(fake.requests.first["Host"]).must_be_nil
+      end
+    end
+
+    it "must set a Host header when the host option is given" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do |fake|
+        connection(host: "cloudstack.internal").send_request("command" => "listZones")
+        _(fake.requests.first["Host"]).must_equal "cloudstack.internal"
+      end
+    end
+  end
+
+  describe "when connecting over https" do
+    it "must verify the peer certificate by default" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do |fake|
+        connection.send_request("command" => "listZones")
+        _(fake.verify_mode).must_equal OpenSSL::SSL::VERIFY_PEER
+      end
+    end
+
+    it "must not verify the peer certificate when ssl_verify is false" do
+      with_fake_http(FakeHttp.new(body: ZONES_BODY)) do |fake|
+        connection(ssl_verify: false).send_request("command" => "listZones")
+        _(fake.verify_mode).must_equal OpenSSL::SSL::VERIFY_NONE
+      end
+    end
+  end
+
+  describe "when signing a request" do
+    # Signatures are what CloudStack authenticates on, so these guard the
+    # base64 encoding against regressions.
+    it "must produce the expected signature for a known request" do
+      data = "apikey=test-key&command=listzones"
+      expected = CGI.escape(
+        [OpenSSL::HMAC.digest("sha1", "test-secret", data)].pack("m0")
+      )
+      _(connection.send(:create_signature, data)).must_equal expected
+    end
+
+    it "must not contain newlines" do
+      # A long parameter string makes the digest encoding wrap if the
+      # encoder inserts line breaks.
+      data = "command=listzones&" + (1..50).map { |i| "param#{i}=value#{i}" }.join("&")
+      _(connection.send(:create_signature, data)).wont_match(/%0A|\n/)
+    end
+  end
+end


### PR DESCRIPTION
Three separate issues stop `cloudstack_client` from being used as a library outside of `cloudstack-cli`. Each is hit on the very first API call, so any consumer fails immediately.

I found these while evaluating the gem as a replacement for `fog-cloudstack` in [kitchen-cloudstack](https://github.com/test-kitchen/kitchen-cloudstack), and I'd like to depend on it — hence the PR rather than a bug report.

### 1. `host.present?` is ActiveSupport

`send_request` calls `host.present?`, but the gem neither defines nor requires `present?`:

```ruby
req['Host'] = host if host.present?
```

Every request raises `NoMethodError: undefined method 'present?' for nil`. Worse, the surrounding `rescue => e` swallows it and reports the wrong cause:

```
CloudstackClient::ConnectionError: API URL 'https://cloudstack.example/client/api'
  is not reachable (after 1 attempt): undefined method 'present?' for nil
```

Bisecting the releases:

| Version | Date | Works standalone? |
|---|---|---|
| 1.6.0 | Apr 2026 | no |
| 1.5.11, 1.5.9 | 2025, Jul 2024 | no |
| 1.5.8 | Jul 2021 | yes |

Introduced in 8e83c16 (Aug 2022), first released in 1.5.9. It goes unnoticed because it only bites when ActiveSupport isn't loaded. Note that `cloudstack-cli` doesn't depend on ActiveSupport either, so it should be affected too unless something else in that dependency tree is pulling it in.

Fixed with a plain nil/empty check.

### 2. `require "base64"` breaks on Ruby 3.4+

`base64` left the default gems in Ruby 3.4 and is gone entirely in Ruby 4.0, so under bundler:

```
cannot load such file -- base64 (LoadError)
  from lib/cloudstack_client/connection.rb:1
```

CI covers 3.2 and 3.3 only, which is why this hasn't surfaced. The single use is encoding a 20-byte SHA1 digest, where `Base64.encode64(x).chomp` and `[x].pack('m0')` produce identical output (verified across 1000 random digests). So this drops the require rather than adding a runtime dependency to a gem that currently has none — happy to switch to declaring `base64` in the gemspec if you'd prefer.

You may also want to add 3.4 and 4.0 to the CI matrix.

### 3. Certificate verification can't be enabled

```ruby
http.verify_mode = OpenSSL::SSL::VERIFY_NONE
```

Every `https` connection is unverified with no way to opt out, which makes the API key and secret interceptable by anyone on the path.

This adds an `ssl_verify` option, defaulting to `true`:

```ruby
CloudstackClient::Client.new(url, key, secret, ssl_verify: false)
```

**This default is a behaviour change** for anyone pointing at a CloudStack with a self-signed certificate — which is common enough that you may not want it. I've defaulted to secure because that's the safer direction, but say the word and I'll flip it to `false` and leave it purely opt-in.

### Tests

Adds `test/connection_test.rb` with 8 tests covering all three issues, using a local `Net::HTTP` double so no new test dependency is needed. The signature tests are regression guards for the base64 change.

Full suite, Ruby 4.0.6:

```
19 runs, 19 assertions, 0 failures, 0 errors, 0 skips   # api_test
 4 runs,  4 assertions, 0 failures, 0 errors, 0 skips   # client_test
 3 runs,  3 assertions, 0 failures, 0 errors, 0 skips   # configuration_test
 8 runs,  9 assertions, 0 failures, 0 errors, 0 skips   # connection_test (new)
```

Also verified end-to-end against real WEBrick HTTP and HTTPS servers in a process with no ActiveSupport loaded:

```
no ActiveSupport loaded, NilClass#present? undefined -- good
HTTP, no ActiveSupport                         [{"id" => "z1", "name" => "zone1"}]
HTTPS self-signed, ssl_verify default (on)     ConnectionError: SSL_connect ... certificate verify failed
HTTPS self-signed, ssl_verify: false           [{"id" => "z1", "name" => "zone1"}]
```
